### PR TITLE
Added needed #include<stdexcept> for std::out_of_range.

### DIFF
--- a/vcm/vcm.h
+++ b/vcm/vcm.h
@@ -3,6 +3,7 @@
 //
 // Versatile Configuration Management Library
 //
+#include <stdexcept>
 #include <string>
 #include <map>
 #include <deque>


### PR DESCRIPTION
When I tried to build in VS2019 against a Win10 target+build tools, I got errors about std::out_of_range, so I added the needed #include of stdexcept to vcm.h.   Probably on whatever toolchain you use, it was getting pulled in via an existing #include.  The solution builds cleanly for me with this change.