### PR TITLE
fix gcc/clang errors: missing definition for strcmp, memset, memcmp, const enum

### DIFF
--- a/xgm/devices/Audio/echo.cpp
+++ b/xgm/devices/Audio/echo.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "echo.h"
 
 using namespace xgm;

--- a/xgm/devices/CPU/nes_cpu.cpp
+++ b/xgm/devices/CPU/nes_cpu.cpp
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <cstring>
 #include "nes_cpu.h"
 #include "../Memory/nes_mem.h"
 #include "../Misc/nsf2_irq.h"

--- a/xgm/devices/Memory/nes_bank.cpp
+++ b/xgm/devices/Memory/nes_bank.cpp
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <cstring>
 #include "nes_bank.h"
 
 // this workaround solves a problem with mirrored FDS RAM writes

--- a/xgm/devices/Memory/ram64k.cpp
+++ b/xgm/devices/Memory/ram64k.cpp
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <cstring>
 #include "ram64k.h"
 
 namespace xgm

--- a/xgm/devices/Misc/log_cpu.cpp
+++ b/xgm/devices/Misc/log_cpu.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "log_cpu.h"
 #include "../CPU/nes_cpu.h"
 #include "../../player/nsf/nsf.h"

--- a/xgm/devices/Sound/nes_fds.cpp
+++ b/xgm/devices/Sound/nes_fds.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "nes_fds.h"
 
 namespace xgm {

--- a/xgm/devices/Sound/nes_fds.h
+++ b/xgm/devices/Sound/nes_fds.h
@@ -36,7 +36,7 @@ protected:
     UINT32 last_vol;  // for trackinfo
 
     // two wavetables
-    const enum { TMOD=0, TWAV=1 };
+    enum { TMOD=0, TWAV=1 };
     INT32 wave[2][64];
     UINT32 freq[2];
     UINT32 phase[2];
@@ -48,7 +48,7 @@ protected:
     UINT32 mod_write_pos;
 
     // two ramp envelopes
-    const enum { EMOD=0, EVOL=1 };
+    enum { EMOD=0, EVOL=1 };
     bool env_mode[2];
     bool env_disable[2];
     UINT32 env_timer[2];

--- a/xgm/devices/Sound/nes_n106.cpp
+++ b/xgm/devices/Sound/nes_n106.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "nes_n106.h"
 
 namespace xgm {

--- a/xgm/devices/Sound/nes_vrc7.cpp
+++ b/xgm/devices/Sound/nes_vrc7.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "nes_vrc7.h"
 
 namespace xgm

--- a/xgm/player/nsf/nsfplay.cpp
+++ b/xgm/player/nsf/nsfplay.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <typeinfo>
+#include <cstring>
 #include "nsfplay.h"
 
 #include <time.h> // for srand() initialization


### PR DESCRIPTION
Current master builds with the version of `clang` included in OSX, this fixes errors reported by newer versions of clang/gcc. Mainly missing definitions for string functions.

Also fixes an error in `xgm/devices/Sound/nes_fds.h` - that an `enum` can't be `const`