### PR TITLE
Fix remaining gcc/clang "-Wall" warnings

### DIFF
--- a/vcm/vcm.h
+++ b/vcm/vcm.h
@@ -23,7 +23,7 @@
 #if defined(__GNUC__)
 #define UNUSED __attribute__((unused))
 #else
-#define UNUSEED
+#define UNUSED
 #endif
 UNUSED
 static char *vcm_itoa(int value, char *str, int base) {

--- a/vcm/vcm.h
+++ b/vcm/vcm.h
@@ -20,6 +20,12 @@
 #define VCM_MUTEX_DESTROY(m) ::CloseHandle(m)
 #define vcm_itoa(v,s,b) ::itoa(v,s,b)
 #else
+#if defined(__GNUC__)
+#define UNUSED __attribute__((unused))
+#else
+#define UNUSEED
+#endif
+UNUSED
 static char *vcm_itoa(int value, char *str, int base) {
     const char *oct_fmt = "%o";
     const char *dec_fmt = "%d";

--- a/vcm/vcm_ui.h
+++ b/vcm/vcm_ui.h
@@ -29,9 +29,9 @@ namespace vcm
   {
   public:
     enum CtrlType { CT_INVALID, CT_CHECK, CT_SPIN, CT_SLIDER, CT_TEXT, CT_COMBO, CT_ENUM, CT_NOBREAK, CT_USER };
-    const int ctrlType;
     std::string label;
     std::string desc;
+    const int ctrlType;
     std::vector<ValueConv *> vcs;
 
     explicit ValueCtrl ( const std::string &l, const std::string &d, const CtrlType t )

--- a/win/nsf_tag.cpp
+++ b/win/nsf_tag.cpp
@@ -101,7 +101,8 @@ bool NSF_TAG::IsExistSection(bool local)
 int NSF_TAG::CreateTag(const char *title_format)
 {
   int i;
-  char temp[8], *p;
+  char temp[8];
+  const char *p;
 
   WritePrivateProfileString(m_sect,"Title",sdat->title,m_tagf);
   WritePrivateProfileString(m_sect,"Artist",sdat->artist,m_tagf);

--- a/xgm/devices/Audio/fader.h
+++ b/xgm/devices/Audio/fader.h
@@ -47,7 +47,7 @@ namespace xgm
     {
       if (fade_in_ms)
       {
-        const UINT32 MAX_SAMPLES = ~0UL;
+        const UINT32 MAX_SAMPLES = (UINT32)~0UL;
         double samples = (double)fade_in_ms * rate / 1000.0;
         if (samples < (double)MAX_SAMPLES)
         {

--- a/xgm/devices/Audio/filter.cpp
+++ b/xgm/devices/Audio/filter.cpp
@@ -8,21 +8,6 @@ static double HAMMING_window(int n, int M)
   return 0.54 + 0.46 * cos(pi*n/M);
 }
 
-static double HANNING_window(int n, int M)
-{
-  return 0.5 * (1.0 + cos(pi*n/M));
-}
-
-static double BERTLET_window(int n, int M)
-{
-  return 1.0 - (double)n/M;
-}
-
-static double SQR_window(int n, int M)
-{
-  return 1.0;
-}
-
 SimpleFIR::SimpleFIR(int tap_num) {
   N = tap_num|1;
   tap = new INT32[N];

--- a/xgm/devices/Audio/filter.cpp
+++ b/xgm/devices/Audio/filter.cpp
@@ -8,6 +8,21 @@ static double HAMMING_window(int n, int M)
   return 0.54 + 0.46 * cos(pi*n/M);
 }
 
+//static double HANNING_window(int n, int M)
+//{
+//    return 0.5 * (1.0 + cos(pi * n / M));
+//}
+
+//static double BERTLET_window(int n, int M)
+//{
+//    return 1.0 - (double)n / M;
+//}
+
+//static double SQR_window(int n, int M)
+//{
+//    return 1.0;
+//}
+
 SimpleFIR::SimpleFIR(int tap_num) {
   N = tap_num|1;
   tap = new INT32[N];

--- a/xgm/devices/Sound/nes_vrc7.cpp
+++ b/xgm/devices/Sound/nes_vrc7.cpp
@@ -162,7 +162,8 @@ namespace xgm
             {
               if      (i == 6) val = opll->ch_out[9]; // BD
               else if (i == 7) val = opll->ch_out[10] + opll->ch_out[11]; // HH&SD
-              else if (i == 8) val = opll->ch_out[12] + opll->ch_out[13]; // TOM&CYM
+              else             val = opll->ch_out[12] + opll->ch_out[13]; // TOM&CYM
+                  /*  (i == 8) is implied */
             }
             else
             {

--- a/xgm/devices/device.h
+++ b/xgm/devices/device.h
@@ -52,6 +52,7 @@ namespace xgm
      * 各種オプションを設定する(もしあれば)
      */
     virtual void SetOption (int id, int val){};
+    virtual ~IDevice() {};
   };
 
   /**
@@ -77,6 +78,7 @@ namespace xgm
      *  Render() now simply mixes and outputs sound
      */
     virtual void Tick (UINT32 clocks) {}
+    virtual ~IRenderable() {};
   };
 
   /**
@@ -124,6 +126,7 @@ namespace xgm
      * Track info for keyboard view.
      */
     virtual ITrackInfo *GetTrackInfo(int trk){ return NULL; }
+    virtual ~ISoundChip() {};
   };
 
   /**

--- a/xgm/devices/devinfo.h
+++ b/xgm/devices/devinfo.h
@@ -8,6 +8,7 @@ namespace xgm
   {
   public:
     virtual IDeviceInfo *Clone()=0;
+    virtual ~IDeviceInfo() {};
   };
 
   class ITrackInfo : public IDeviceInfo

--- a/xgm/player/nsf/nsf.cpp
+++ b/xgm/player/nsf/nsf.cpp
@@ -63,7 +63,7 @@ static int is_sjis_prefix(int c)
     default_loopnum = l;
   }
 
-  static char *print_time (int time)
+  static const char *print_time (int time)
   {
     static char buf[32];
     int h, m, s, ss = 0;
@@ -87,12 +87,12 @@ static int is_sjis_prefix(int c)
     return buf;
   }
 
-  char *NSF::GetPlaylistString (const char *format, bool b)
+  const char *NSF::GetPlaylistString (const char *format, bool b)
   {
     static char buf[NSF_MAX_PATH + 128];
     char *p = buf;
 
-    char *t = GetTitleString (format);
+    const char *t = GetTitleString (format);
 
     p += sprintf (p, "%s::NSF,$%02x,", filename, song + 1);
 
@@ -124,7 +124,7 @@ static int is_sjis_prefix(int c)
   }
 
 
-  char *NSF::GetTitleString (const char *format, int song)
+  const char *NSF::GetTitleString (const char *format, int song)
   {
     int wp=0;
 

--- a/xgm/player/nsf/nsf.cpp
+++ b/xgm/player/nsf/nsf.cpp
@@ -903,7 +903,6 @@ static int is_sjis_prefix(int c)
   void NSF::DebugOut ()
   {
     int i;
-    char buf[256] = "";
 
     DEBUG_OUT ("Magic:    %4s\n", magic);
     DEBUG_OUT ("Version:  %d\n", version);
@@ -948,8 +947,7 @@ static int is_sjis_prefix(int c)
     DEBUG_OUT ("Extra:     ");
     for (i = 0; i < 4; i++)
     {
-      DEBUG_OUT (buf, "[%02x]", extra[i]);
-      DEBUG_OUT (buf);
+      DEBUG_OUT ("[%02x]", extra[i]);
     }
     DEBUG_OUT ("\n");
     DEBUG_OUT ("DataSize: %d\n", bodysize);

--- a/xgm/player/nsf/nsf.cpp
+++ b/xgm/player/nsf/nsf.cpp
@@ -47,7 +47,7 @@ static int is_sjis_prefix(int c)
     nsfe_image = NULL;
     nsfe_plst = NULL;
     nsfe_plst_size = 0;
-    for (int i=0; i<NSFE_MIXES; ++i) nsfe_mixe[i] = NSFE_MIXE_DEFAULT;
+    for (unsigned int i=0; i<NSFE_MIXES; ++i) nsfe_mixe[i] = NSFE_MIXE_DEFAULT;
   }
 
   NSF::~NSF ()
@@ -66,12 +66,11 @@ static int is_sjis_prefix(int c)
   static const char *print_time (int time)
   {
     static char buf[32];
-    int h, m, s, ss = 0;
+    int h, m, s = 0;
 
     if (time < 0)
       return "";
 
-    ss = (time % 1000) / 10;
     time /= 1000;
     s = time % 60;
     time /= 60;
@@ -458,7 +457,7 @@ static int is_sjis_prefix(int c)
     nsfe_plst_size = 0;
 
     // entries 'tlbl', 'taut', 'time', 'fade', 'psfx'
-    for (int i=0; i < NSFE_ENTRIES; ++i)
+    for (unsigned int i=0; i < NSFE_ENTRIES; ++i)
     {
       nsfe_entry[i].tlbl = "";
       nsfe_entry[i].taut = "";
@@ -468,7 +467,7 @@ static int is_sjis_prefix(int c)
     }
 
     // 'mixe'
-    for (int i=0; i<NSFE_MIXES; ++i) nsfe_mixe[i] = NSFE_MIXE_DEFAULT;
+    for (unsigned int i=0; i<NSFE_MIXES; ++i) nsfe_mixe[i] = NSFE_MIXE_DEFAULT;
 
     // load the NSF or NSFe
 

--- a/xgm/player/nsf/nsf.cpp
+++ b/xgm/player/nsf/nsf.cpp
@@ -279,7 +279,7 @@ static int is_sjis_prefix(int c)
     ext = strchr(fn,'.');
     if (ext)
     {
-      while (ext_next = strchr(ext+1,'.')) ext = ext_next;
+      while ((ext_next = strchr(ext+1,'.'))) ext = ext_next;
     }
     else ext = "";
 

--- a/xgm/player/nsf/nsf.cpp
+++ b/xgm/player/nsf/nsf.cpp
@@ -838,7 +838,6 @@ static int is_sjis_prefix(int c)
         }
         else if (!strcmp(cid, "psfx"))
         {
-          unsigned int n=0;
           for (unsigned int i=0; i<chunk_size; ++i)
           {
             UINT8 track = chunk[i];

--- a/xgm/player/nsf/nsf.h
+++ b/xgm/player/nsf/nsf.h
@@ -37,11 +37,11 @@ namespace xgm
     char title_nsf[32];
     char artist_nsf[32];
     char copyright_nsf[32];
-    char* title;
-    char* artist;
-    char* copyright;
-    char* ripper; // NSFe only
-    char* text; // NSFe only
+    const char* title;
+    const char* artist;
+    const char* copyright;
+    const char* ripper; // NSFe only
+    const char* text; // NSFe only
     UINT32 text_len; // NSFe only
     UINT16 speed_ntsc;
     UINT8 bankswitch[8];
@@ -113,8 +113,8 @@ namespace xgm
      *
      * @return タイトル文字列 (作曲者 - タイトル)
      */
-    char *GetTitleString (const char *format=NULL, int song=-1);
-    char *GetPlaylistString (const char *format, bool b);
+    const char *GetTitleString (const char *format=NULL, int song=-1);
+    const char *GetPlaylistString (const char *format, bool b);
     int GetLength ();
     void SetTitleString (char *);
     void SetDefaults (int playtime, int fadetime, int loopnum);

--- a/xgm/player/nsf/nsfconfig.cpp
+++ b/xgm/player/nsf/nsfconfig.cpp
@@ -10,10 +10,10 @@
 
 using namespace xgm;
 
-char *NSFPlayerConfig::dname[NES_DEVICE_MAX] =
+const char *NSFPlayerConfig::dname[NES_DEVICE_MAX] =
   { "APU1", "APU2", "5B", "MMC5", "N163", "VRC6", "VRC7", "FDS" };
 
-char *NSFPlayerConfig::channel_name[NES_CHANNEL_MAX] =
+const char *NSFPlayerConfig::channel_name[NES_CHANNEL_MAX] =
   {
       "SQR0", "SQR1", "TRI", "NOISE", "DMC",
       "FDS",

--- a/xgm/player/nsf/nsfconfig.h
+++ b/xgm/player/nsf/nsfconfig.h
@@ -47,10 +47,10 @@ namespace xgm
     }
 
     /** デバイス毎の名前 */
-    static char *dname[NES_DEVICE_MAX];
+    static const char *dname[NES_DEVICE_MAX];
 
     // for channel/pan/mix
-    static char *channel_name[NES_CHANNEL_MAX]; // name of channel
+    static const char *channel_name[NES_CHANNEL_MAX]; // name of channel
     static int channel_device[NES_CHANNEL_MAX]; // device enum of channel
     static int channel_device_index[NES_CHANNEL_MAX]; // device channel index
     static int channel_track[NES_CHANNEL_MAX]; // trackinfo for channel

--- a/xgm/player/nsf/nsfplay.cpp
+++ b/xgm/player/nsf/nsfplay.cpp
@@ -11,7 +11,6 @@ namespace xgm
   {
     nsf = NULL;
 
-    const std::type_info &ti = typeid(this);
     sc[APU] = (apu = new NES_APU());
     sc[DMC] = (dmc = new NES_DMC());
     sc[FDS] = (fds = new NES_FDS());
@@ -96,7 +95,6 @@ namespace xgm
   void NSFPlayer::Reload ()
   {
     int i, bmax = 0;
-    UINT32 offset = 0;
 
     assert (nsf);
 
@@ -418,7 +416,6 @@ void NSFPlayer::SetPlayFreq (double r)
     int region_register = (region == REGION_PAL) ? 1 : 0;
     if (region == REGION_DENDY && (nsf->regn & 4)) region_register = 2; // use 2 for Dendy iff explicitly supported, otherwise 0
 
-    int play_addr = (nsf->nsf2_bits & 0x40) ? -1 : nsf->play_address; // suppress play
     cpu.Start (
         nsf->init_address,
         nsf->play_address,

--- a/xgm/player/nsf/nsfplay.cpp
+++ b/xgm/player/nsf/nsfplay.cpp
@@ -65,7 +65,7 @@ namespace xgm
     return playtime_detected;
   }
 
-  char *NSFPlayer::GetTitleString ()
+  const char *NSFPlayer::GetTitleString ()
   {
     if (nsf == NULL) return "(not loaded)";
 

--- a/xgm/player/nsf/nsfplay.h
+++ b/xgm/player/nsf/nsfplay.h
@@ -148,7 +148,7 @@ namespace xgm
     virtual UINT32 Skip (UINT32 length);
 
     /** ‹È–¼‚ðŽæ“¾‚·‚é */
-    virtual char *GetTitleString ();
+    virtual const char *GetTitleString ();
 
     /** ‰‰‘tŽžŠÔ‚ðŽæ“¾‚·‚é */
     virtual int GetLength ();

--- a/xgm/player/nsf/pls/ppls.cpp
+++ b/xgm/player/nsf/pls/ppls.cpp
@@ -329,11 +329,10 @@ void PLSITEM_delete(PLSITEM *elem)
 static const char *print_time(int time)
 {
   static char buf[32] ;
-  int h,m,s,ss = 0 ;
+  int h,m,s = 0 ;
 
   if(time<0) return "" ;
 
-  ss = (time%1000) / 10 ;
   time /= 1000 ;
   s = time%60 ;
   time /= 60 ;

--- a/xgm/player/nsf/pls/ppls.cpp
+++ b/xgm/player/nsf/pls/ppls.cpp
@@ -326,7 +326,7 @@ void PLSITEM_delete(PLSITEM *elem)
   free(elem) ;
 }
 
-static char *print_time(int time)
+static const char *print_time(int time)
 {
   static char buf[32] ;
   int h,m,s,ss = 0 ;

--- a/xgm/player/player.h
+++ b/xgm/player/player.h
@@ -128,7 +128,7 @@ namespace xgm {
      NEVER_LOOPの場合はループしないデータ，INFINITE_LOOPの場合は無限ループするデータである．
      */
     virtual int  GetLoopCount(){ return NEVER_LOOP; }
-    virtual char* GetTitleString(){ return "UNKNOWN"; }
+    virtual const char* GetTitleString(){ return "UNKNOWN"; }
     virtual int GetLength(){ return 5*60*1000; }
     
     /* 番号idの時間timeでのデバイス情報を取得 time==-1の時は現在のデバイス情報を返す */

--- a/xgm/player/soundData.h
+++ b/xgm/player/soundData.h
@@ -34,7 +34,7 @@ namespace xgm
      * タイトルの取得
      * @return タイトル情報
      */
-    virtual char *GetTitleString(const char *format=NULL){ return ""; }
+    virtual const char *GetTitleString(const char *format=NULL, int song=-1){ return ""; }
 
     /**
      * タイトルの設定


### PR DESCRIPTION
This fixes all warnings when compiling with "-Wall" on the latest gcc and clang