### PR TITLE
xgm: include cstdlib (for ::rand) in nes_dmc

### DIFF
--- a/xgm/devices/Sound/nes_dmc.cpp
+++ b/xgm/devices/Sound/nes_dmc.cpp
@@ -1,5 +1,6 @@
 #include "nes_dmc.h"
 #include "nes_apu.h"
+#include <cstdlib>
 
 namespace xgm
 {


### PR DESCRIPTION
Fixes compilation with gcc/g++ <= 6