### PR TITLE
xgm: detach from config observer when destroying player

### DIFF
--- a/xgm/player/player.h
+++ b/xgm/player/player.h
@@ -34,9 +34,12 @@ namespace xgm {
 
     Player()
     {
+        config = nullptr;
     }
 
     virtual ~Player(){ 
+        if(config != nullptr)
+            config->DetachObserver(this);
     }
 
     /**

--- a/xgm/player/player.h
+++ b/xgm/player/player.h
@@ -34,11 +34,11 @@ namespace xgm {
 
     Player()
     {
-        config = nullptr;
+        config = NULL;
     }
 
     virtual ~Player(){ 
-        if(config != nullptr)
+        if(config != NULL)
             config->DetachObserver(this);
     }
 


### PR DESCRIPTION
I had a program with a long-running `NSFPlayerConfig` instance, but my `NSFPlayer` instance was short-lived. Since the player instance never called DetachObserver, when creating my replacement instance of NSFPlayer, I would get a segfault.