### PR TITLE
Adds method to detach Observers from Observables

### DIFF
--- a/vcm/vcm.h
+++ b/vcm/vcm.h
@@ -92,6 +92,7 @@ namespace vcm
   {
   public:
     virtual void Notify(int)=0;
+    virtual void Detach()=0;
   };
 
   class Observable
@@ -127,6 +128,12 @@ namespace vcm
       std::set<ObserverI *>::iterator it;
       for(it=oblist.begin();it!=oblist.end();it++)
         (*it)->Notify(id);
+    }
+
+    virtual ~Observable() {
+      std::set<ObserverI *>::iterator it;
+      for(it=oblist.begin();it!=oblist.end();it++)
+        (*it)->Detach();
     }
   }; 
 

--- a/xgm/player/player.h
+++ b/xgm/player/player.h
@@ -66,6 +66,10 @@ namespace xgm {
      */
     virtual void Notify(int param){};
 
+    virtual void Detach() {
+        config = NULL;
+    }
+
     /**
      * 演奏データをロードする
      * <P>


### PR DESCRIPTION
This should fix a use-after-free bug.

The player object calls DetachObserver in its destructor, which may already be freed based on destructor order.

Example:

```
xgm::NSFPlayer player;
xgm::NSFPlayerConfig config;

player.SetConfig(&config);
```

This will result in a crash (tested on arch linux), since `config` will be destroyed before `player`, but `player` will attempt to call `DetachObserver` on `config` during destruction.

This proposed fix is to have Observables request that their Observers detach when destroyed (just replace the pointer with NULL).  This allows the destructors to occur in any order.