### PR TITLE
Correctly handle tracks with no metadata.

### DIFF
--- a/contrib/nsf2flac
+++ b/contrib/nsf2flac
@@ -56,6 +56,7 @@ function jq_on_track {
 declare -A tags
 keys="$(jq_on_track 'keys[]')" || exit $?
 while read -r key; do
+    [[ -z "$key" ]] && continue
     tags["$key"]="$(jq_on_track '.[$key]' --arg key "$key")" || exit $?
 done <<< "$keys"
 

--- a/contrib/nsfmeta.cpp
+++ b/contrib/nsfmeta.cpp
@@ -190,7 +190,7 @@ int main(int argc, char *argv[]) {
     json nsf_json = json::array();
 
     for (int track = 0; track < nsf.GetSongNum(); track++) {
-      json &track_json = nsf_json[track];
+      json &track_json = nsf_json[track] = json::object();
       nsf.SetSong(track);
 
       if (std::string_view title(nsf.title); !title.empty()) {


### PR DESCRIPTION
Previously, nsfmeta would output an array of tracks with null tracks.
Instead now, it outputs empty objects for each track.

These empty objects also cause an error in nsf2flac, which this change
also fixes, since it attempts to iterate once over the empty string as
track metadata.