### PR TITLE
Fix linux build

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -7,6 +7,8 @@ DYNLIB_EXT=.so
 EXE_EXT=
 INSTALL=install
 
+LIBS_ICONV = -liconv
+
 DESTDIR=
 PREFIX=/usr/local
 LIBDIR=$(DESTDIR)$(PREFIX)/lib
@@ -171,7 +173,7 @@ release_debug:
 demo: nsf2wav$(EXE_EXT)
 
 nsfmeta$(EXE_EXT): $(OBJDIR)/nsfmeta.o $(LIB_STATIC)
-	$(CXX) -o $@ $^ $(LDFLAGS_EXTRA) -liconv
+	$(CXX) -o $@ $^ $(LDFLAGS_EXTRA) $(LIBS_ICONV)
 
 nsf2wav$(EXE_EXT): $(OBJDIR)/nsf2wav.o $(LIB_STATIC)
 	$(CXX) -o $@ $^ $(LDFLAGS_EXTRA)

--- a/contrib/nsf2wav.cpp
+++ b/contrib/nsf2wav.cpp
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sysexits.h>
+#include <string.h>
 
 #include <algorithm>
 #include <memory>


### PR DESCRIPTION
Hi there, got a few linux-specific fixes.

nsf2wav now uses strerror, which is defined in string.h on some systems

Makefile previously linked with `-liconv`, but iconv is built-in to glibc (and possibly other c libraries, not sure). Placing it in a variable so it can be built with `make LIBS_ICONV=` to specify no flags are needed.