### PR TITLE
MMC5 and VRC6: Reset on construction, ensure values are initialized

### DIFF
--- a/xgm/devices/Sound/nes_mmc5.cpp
+++ b/xgm/devices/Sound/nes_mmc5.cpp
@@ -33,6 +33,7 @@ namespace xgm
     for(int c=0;c<2;++c)
         for(int t=0;t<3;++t)
             sm[c][t] = 128;
+    Reset();
   }
 
   NES_MMC5::~NES_MMC5 ()
@@ -55,6 +56,11 @@ namespace xgm
     envelope_counter[0] = 0;
     envelope_counter[1] = 0;
     frame_sequence_count = 0;
+
+    freq[0] = 0;
+    freq[1] = 0;
+    enable[0] = false;
+    enable[1] = false;
 
     for (i = 0; i < 8; i++)
       Write (0x5000 + i, 0);

--- a/xgm/devices/Sound/nes_vrc6.cpp
+++ b/xgm/devices/Sound/nes_vrc6.cpp
@@ -14,6 +14,7 @@ namespace xgm
     for(int c=0;c<2;++c)
         for(int t=0;t<3;++t)
             sm[c][t] = 128;
+    Reset();
   }
 
   NES_VRC6::~NES_VRC6 ()
@@ -74,6 +75,15 @@ namespace xgm
 
   void NES_VRC6::Reset ()
   {
+    freq[0] = 0;
+    freq[1] = 0;
+    freq[2] = 0;
+    counter[0] = 0;
+    counter[1] = 0;
+    counter[2] = 0;
+    enable[0] = 0;
+    enable[1] = 0;
+    enable[2] = 0;
     Write (0x9003, 0);
     for (int i = 0; i < 3; i++)
     {
@@ -83,9 +93,6 @@ namespace xgm
     }
     count14 = 0;
     mask = 0;
-    counter[0] = 0;
-    counter[1] = 0;
-    counter[2] = 0;
     phase[0] = 0;
     phase[0] = 1;
     phase[0] = 2;

--- a/xgm/player/nsf/nsfplay.cpp
+++ b/xgm/player/nsf/nsfplay.cpp
@@ -40,6 +40,7 @@ namespace xgm
 
     nch = 1;
     infinite = false;
+    last_out = 0;
   }
 
   NSFPlayer::~NSFPlayer ()


### PR DESCRIPTION
Hi there -

I ran into a segfault recently. I compiled NSFPlay such that uninitialized data is randomized.

When NSFPlayer::Reset() is called, it iterates through the different chips and calls Tick(0). So in the NES_MMC5 object, in `calc_sqr` - it would wind up trying to use an out-of-bounds index when reading from the `sqrtbl`, since in here:

```c++
ret = sqrtbl[duty[i]][sphase[i]] ? v : 0;
```

`sphase[i]` will have some random, large value in it (and possibly `duty` but I only inspected the value in `sphase`). So - there's the out of bounds memory read.

I noticed that MMC5 and VRC6 don't call their `Reset` method in their constructor, whereas some other chips do - so I added that, and made sure values used in `Reset` are initialized (for example, in MMC5: the call to `Write(0x5003)` checks the value of `enable`, which hasn't been initialized yet).

I wasn't 100% if this is the right approach, or if these values should be set in the constructor instead and not call `Reset`? Happy to rework this to set defaults in the constructor instead, if there's a reason to not call `Reset()` in the constructor.