### PR TITLE
nsf2wav: disable apu tri & noise phase randomization

### DIFF
--- a/contrib/nsf2wav.cpp
+++ b/contrib/nsf2wav.cpp
@@ -310,6 +310,8 @@ int main(int argc, char *argv[]) {
     }
 
     config["MASTER_VOLUME"] = 256; /* default volume = 128 */
+    config["APU2_OPTION5"] = 0; /* disable randomized noise phase at reset */
+    config["APU2_OPTION7"] = 0; /* disable randomized tri phase at reset */
 
     player.SetConfig(&config);
     if(!player.Load(&nsf)) {


### PR DESCRIPTION
Disabled nsf2wav randomized noise & tri phases.

This is for my regression tests that compare nsf wav output to a reference. The phases can't be random for these tests to work well.