### PR TITLE
xgm: Declare NSF version 2 body size as NSF2 PRG size

### DIFF
--- a/xgm/devices/Memory/nes_bank.cpp
+++ b/xgm/devices/Memory/nes_bank.cpp
@@ -52,8 +52,7 @@ namespace xgm
     int total_size = ((offset & 0xfff) + size);
     bankmax = (total_size >> 12); // count of full banks
     if (total_size & 0xfff) bankmax += 1; // include last partial bank
-    if (bankmax > 256)
-      return false;
+    if (bankmax > 256) bankmax = 256;
 
     if (image)
       delete[]image;

--- a/xgm/player/nsf/nsf.cpp
+++ b/xgm/player/nsf/nsf.cpp
@@ -589,6 +589,7 @@ void sjis_legacy(char* s, const unsigned int length)
             nsf_error = nsfe_error;
             return false; // NSF2 bit 7 indicates metadata parsing is mandatory
         }
+        bodysize = suffix - 0x80;
     }
 
     nsf_error = "";


### PR DESCRIPTION
This prevents NSFe metadata being included as part of the PRG ROM size, which then prevents an access violation error when reading the ROM image in 1MB NSFs.