### PR TITLE
fix build under MSYS2

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -62,7 +62,8 @@ LIBXGM_CPP_SRCS = \
 	../xgm/player/nsf/nsfconfig.cpp \
 	../xgm/player/nsf/nsfplay.cpp \
 	../xgm/player/nsf/pls/ppls.cpp \
-	../xgm/player/nsf/pls/sstream.cpp
+	../xgm/player/nsf/pls/sstream.cpp \
+	../xgm/fileutil.cpp
 
 LIBXGM_C_SRCS = \
 	../xgm/devices/Sound/legacy/emu2149.c \
@@ -140,6 +141,7 @@ LIBXGM_HEADERS = \
 	../xgm/player/soundData.h \
 	../xgm/utils/tagctrl.h \
 	../xgm/version.h \
+	../xgm/fileutil.h \
 	../xgm/xgm.h \
 	../xgm/xtypes.h
 

--- a/contrib/nsf2wav.cpp
+++ b/contrib/nsf2wav.cpp
@@ -10,8 +10,13 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sysexits.h>
 #include <string.h>
+
+#if __has_include(<sysexits.h>)
+#  include <sysexits.h>
+#else
+#  define EX_USAGE        64
+#endif // __has_include(<sysexits.h>)
 
 #include <algorithm>
 #include <memory>


### PR DESCRIPTION
This patch introduced two changes:

1. `fileutil.{h,cpp}` should be inside the provided `Makefile`, which is currently missing.
2. `<sysexits.h>` isn't something that available everywhere, so we use `__has_include` to check if it's exist.