### PR TITLE
fix contrib build on linux and macos (nsf2wav, nsfmeta), add contrib to github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,21 +30,3 @@ jobs:
         with:
           name: nsfplay-unstable--${{ env.BUILD_TAG }}
           path: artifact/
-
-  build-contrib-ubuntu:
-    name: Contrib Ubuntu
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout Files
-        uses: actions/checkout@v4
-      - name: Build
-        run: make -C contrib -j
-
-  build-contrib-macos:
-    name: Contrib macOS
-    runs-on: macos-14
-    steps:
-      - name: Checkout Files
-        uses: actions/checkout@v4
-      - name: Build
-        run: make -C contrib -j

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,21 @@ jobs:
         with:
           name: nsfplay-unstable--${{ env.BUILD_TAG }}
           path: artifact/
+
+  build-contrib-ubuntu:
+    name: Contrib Ubuntu
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Files
+        uses: actions/checkout@v4
+      - name: Build
+        run: make -C contrib -j
+
+  build-contrib-macos:
+    name: Contrib macOS
+    runs-on: macos-14
+    steps:
+      - name: Checkout Files
+        uses: actions/checkout@v4
+      - name: Build
+        run: make -C contrib -j

--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -1,0 +1,44 @@
+name: NSFPlay contrib build test
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-msys2:
+    name: Contrib MSYS2
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Files
+        uses: actions/checkout@v4
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          install: make mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-libiconv
+      - name: Build
+        shell: msys2 {0}
+        run: make -C contrib -j
+
+  build-contrib-ubuntu:
+    name: Contrib Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Files
+        uses: actions/checkout@v4
+      - name: Build
+        run: make -C contrib -j
+
+  build-contrib-macos:
+    name: Contrib macOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Files
+        uses: actions/checkout@v4
+      - name: Build
+        run: make -C contrib -j

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -36,9 +36,13 @@ ifeq ($(CXXFLAGS),)
 CXXFLAGS := $(CXXFLAGS_DEBUG)
 endif
 
-UNAME := $(shell uname -s)
-ifeq ($(UNAME),Darwin)
-	LDFLAGS_EXTRA = -liconv
+ifeq ($(OS),Windows_NT)
+	LDFLAGS_EXTRA := -liconv
+else ifeq ($(shell uname),Darwin)
+	LDFLAGS_EXTRA := -liconv
+else
+	# iconv assumed to be part of the standard C library
+	LDFLAGS_EXTRA :=
 endif
 
 LIBXGM_CPP_SRCS = \

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -7,8 +7,6 @@ DYNLIB_EXT=.so
 EXE_EXT=
 INSTALL=install
 
-LIBS_ICONV = -liconv
-
 DESTDIR=
 PREFIX=/usr/local
 LIBDIR=$(DESTDIR)$(PREFIX)/lib
@@ -19,14 +17,16 @@ OBJDIR := .objs
 LIB_STATIC=$(STATIC_PREFIX)nsfplay$(STATIC_EXT)
 LIB_DYNLIB=$(DYNLIB_PREFIX)nsfplay$(DYNLIB_EXT)
 
-CXXFLAGS_DEBUG := -g -O0 -Wall -fPIC -std=c++17
-CFLAGS_DEBUG := -g -O0 -Wall -fPIC
+CFLAGS_WARN := -Wall -Wno-deprecated-declarations
 
-CXXFLAGS_RELEASE := -g0 -O2 -Wall -fPIC -std=c++17 -DNDEBUG
-CFLAGS_RELEASE := -g0 -O2 -Wall -fPIC -DNDEBUG
+CXXFLAGS_DEBUG := -g -O0 $(CFLAGS_WARN) -fPIC -std=c++17
+CFLAGS_DEBUG := -g -O0 $(CFLAGS_WARN) -fPIC
 
-CXXFLAGS_RELEASE_DEBUG := -g -O2 -Wall -fPIC -std=c++17 -DNDEBUG
-CFLAGS_RELEASE_DEBUG := -g -O2 -Wall -fPIC -DNDEBUG
+CXXFLAGS_RELEASE := -g0 -O2 $(CFLAGS_WARN) -fPIC -std=c++17 -DNDEBUG
+CFLAGS_RELEASE := -g0 -O2 $(CFLAGS_WARN) -fPIC -DNDEBUG
+
+CXXFLAGS_RELEASE_DEBUG := -g -O2 $(CFLAGS_WARN) -fPIC -std=c++17 -DNDEBUG
+CFLAGS_RELEASE_DEBUG := -g -O2 $(CFLAGS_WARN) -fPIC -DNDEBUG
 
 ifeq ($(CFLAGS),)
 CFLAGS := $(CFLAGS_DEBUG)
@@ -34,6 +34,11 @@ endif
 
 ifeq ($(CXXFLAGS),)
 CXXFLAGS := $(CXXFLAGS_DEBUG)
+endif
+
+UNAME := $(shell uname -s)
+ifeq ($(UNAME),Darwin)
+	LDFLAGS_EXTRA = -liconv
 endif
 
 LIBXGM_CPP_SRCS = \
@@ -175,7 +180,7 @@ release_debug:
 demo: nsf2wav$(EXE_EXT)
 
 nsfmeta$(EXE_EXT): $(OBJDIR)/nsfmeta.o $(LIB_STATIC)
-	$(CXX) -o $@ $^ $(LDFLAGS_EXTRA) $(LIBS_ICONV)
+	$(CXX) -o $@ $^ $(LDFLAGS_EXTRA)
 
 nsf2wav$(EXE_EXT): $(OBJDIR)/nsf2wav.o $(LIB_STATIC)
 	$(CXX) -o $@ $^ $(LDFLAGS_EXTRA)

--- a/xgm/fileutil.cpp
+++ b/xgm/fileutil.cpp
@@ -1,9 +1,13 @@
 #include "fileutil.h"
-
+#if defined(_WIN32)
 #include <windows.h>
+#else
+#include <iconv.h>
+#endif
 
 FILE* fopen_utf8(const char* filename, const char* mode)
 {
+#if defined(_WIN32)
 	const int MAX_WPATH = 2048;
 	const int MAX_WMODE = 16;
 	wchar_t wfilename[MAX_WPATH];
@@ -12,4 +16,33 @@ FILE* fopen_utf8(const char* filename, const char* mode)
 	utf8_file(filename,wfilename,MAX_WPATH);
 	utf8_file(mode,wmode,MAX_WMODE);
 	return _wfopen(wfilename,wmode);
+#else
+	return fopen(filename, mode); // assume non-Windows OS has UTF-8 path names
+#endif
 }
+
+#if !defined(_WIN32)
+int mbs_to_utf8(char* outbuf, size_t outsize, const char* incharset, const char* inbuf, size_t insize)
+{
+	char *inptr = (char *) inbuf;
+	char *outptr = outbuf;
+	iconv_t cd = iconv_open("UTF-8", incharset);
+
+	if (cd == (iconv_t) -1)
+	{
+		outbuf[0] = '\0';
+		return -1;
+	}
+
+	while (insize > 0)
+	{
+		if (iconv(cd, &inptr, &insize, &outptr, &outsize) == (size_t) -1)
+			break;
+	}
+	if (outsize >= 1)
+		*outptr = '\0';
+
+	iconv_close(cd);
+	return outptr - outbuf;
+}
+#endif

--- a/xgm/fileutil.h
+++ b/xgm/fileutil.h
@@ -16,3 +16,9 @@ extern FILE* fopen_utf8(const char* filename, const char* mode);
 // convert a utf8 filename to wchar_t, returns length
 // use wfile=NULL, wfile_len=0 to query length without writing the conversion to wfile
 #define utf8_file(utf8,wfile,wfile_len) MultiByteToWideChar(CP_UTF8,0,(utf8),-1,(wfile),(wfile_len))
+
+#ifndef _WIN32
+// convert multibyte charset string to utf-8 string using iconv
+// returns number converted characters or -1 on error
+extern int mbs_to_utf8(char* outbuf, size_t outsize, const char* incharset, const char* inbuf, size_t insize);
+#endif

--- a/xgm/player/nsf/nsf.cpp
+++ b/xgm/player/nsf/nsf.cpp
@@ -1,4 +1,4 @@
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_WIN32)
 #include <windows.h>
 #else
 #define stricmp strcasecmp
@@ -62,10 +62,14 @@ void sjis_legacy(char* s, const unsigned int length)
 	if (utf8) return; // valid UTF8, don't convert
 
 	// if not valid UTF8 assume legacy shift-JIS
+#if defined(_WIN32)
 	// (convenient conversion back and forth using windows wide character)
 	wchar_t w[1024];
 	MultiByteToWideChar(932,0,s,-1,w,1024);
 	WideCharToMultiByte(CP_UTF8,0,w,-1,s,length,NULL,NULL);
+#else
+	mbs_to_utf8(s, length, "SHIFT_JIS", s, length);
+#endif
 }
 
 


### PR DESCRIPTION
Minor changes to fix contrib build under macOS. Didn't test but might work for Linux and other GNU/posix too (if not, probably only minor changes are needed to fix that).

@bbbradsmith I needs a NSF file with old Shift JIS text to complete this. Do you have some?