### PR TITLE
improve apu pulse channel nonlinear mixing precision

### DIFF
--- a/xgm/devices/Sound/nes_apu.cpp
+++ b/xgm/devices/Sound/nes_apu.cpp
@@ -147,19 +147,18 @@ namespace xgm
 
     if(option[OPT_NONLINEAR_MIXER])
     {
-        INT32 voltage = square_table[out[0] + out[1]];
-        m[0] = out[0] << 6;
-        m[1] = out[1] << 6;
-        INT32 ref = m[0] + m[1];
+        INT32 ref = out[0] + out[1];
         if (ref > 0)
         {
-            m[0] = (m[0] * voltage) / ref;
-            m[1] = (m[1] * voltage) / ref;
+            INT32 voltage = square_table[ref];
+            m[0] = (out[0] * voltage) / ref;
+            m[1] = (out[1] * voltage) / ref;
         }
         else
         {
-            m[0] = voltage;
-            m[1] = voltage;
+            // square_table[0] = 0;
+            m[0] = 0;
+            m[1] = 0;
         }
     }
     else
@@ -170,11 +169,11 @@ namespace xgm
 
     b[0]  = m[0] * sm[0][0];
     b[0] += m[1] * sm[0][1];
-    b[0] >>= 7;
+    b[0] >>= 11;
 
     b[1]  = m[0] * sm[1][0];
     b[1] += m[1] * sm[1][1];
-    b[1] >>= 7;
+    b[1] >>= 11;
 
     return 2;
   }
@@ -190,8 +189,8 @@ namespace xgm
     option[OPT_NEGATE_SWEEP_INIT] = false;
 
     square_table[0] = 0;
-    for(int i=1;i<32;i++) 
-        square_table[i]=(INT32)((8192.0*95.88)/(8128.0/i+100));
+    for(int i=1;i<32;i++)
+        square_table[i]=(INT32)round((16.0*8192.0*95.88)/(8128.0/i+100));
 
     square_linear = square_table[15]; // match linear scale to one full volume square of nonlinear
 

--- a/xgm/devices/Sound/nes_apu.cpp
+++ b/xgm/devices/Sound/nes_apu.cpp
@@ -190,7 +190,7 @@ namespace xgm
 
     square_table[0] = 0;
     for(int i=1;i<32;i++)
-        square_table[i]=(INT32)round((16.0*8192.0*95.88)/(8128.0/i+100));
+        square_table[i]=(INT32)round(((1<<17)*95.88)/(8128.0/i+100));
 
     square_linear = square_table[15]; // match linear scale to one full volume square of nonlinear
 


### PR DESCRIPTION
Minor improvements to pulse channels non-linear mixing precision by increasing decimal bits in the lookup. Stereo mix on default (mono) setting now produces same output as the lookup. This fixes a 1/8192 error on output on some pulse 1 and 2 level combinations and removes some redundant left bit shifting.

Here is a python script used for testing:

```python
import itertools

square_table_old = [0] + [int((8192.0*95.88)/(8128.0/i+100)) for i in range(1, 32)]
square_table_new = [0] + [round((16.0*8192.0*95.88)/(8128.0/i+100)) for i in range(1, 32)]

def mix_mono_old(out):
    return (square_table_old[out[0] + out[1]],) * 2

def mix_mono_new(out):
    return (square_table_new[out[0] + out[1]] >> 4,) * 2

def mix_old(out, sm):
    voltage = square_table_old[out[0] + out[1]]
    m = [x << 6 for x in out]
    ref = m[0] + m[1]
    if ref > 0:
        m = [(x * voltage) // ref for x in m]
    else:
        m = [voltage for _ in m]
    b = ((m[0]*sm[i][0] + m[1]*sm[i][1]) >> 7 for i in range(2))
    return tuple(b)

def mix_new(out, sm):
    ref = out[0] + out[1]
    if ref > 0:
        voltage = square_table_new[ref]
        m = [(x * voltage) // ref for x in out]
    else:
        m = [0] * 2
    b = ((m[0]*sm[i][0] + m[1]*sm[i][1]) >> 11 for i in range(2))
    return tuple(b)

def stereo_mix(pan):
    a,b = min(pan,128),min(256-pan,128)
    return ((a,b), (b,a))

sm_mono = stereo_mix(128)

print(f"\n# test 1: new mono vs new stereo (diffs)\n")
print("| out      | new mono     | new stereo   |")
print("| -------- | ------------ | ------------ |")
for out in itertools.combinations(range(16), 2):
    mono = mix_mono_new(out)
    new = mix_new(out, sm_mono)
    if mono != new:
        print(f"| {str(out):8} | {str(mono):12} | {str(new):12} |")

print(f"\n# test 2: old mono vs old stereo (diffs)\n")
print("| out      | old mono     | old stereo   |")
print("| -------- | ------------ | ------------ |")
for out in itertools.combinations(range(16), 2):
    mono = mix_mono_old(out)
    old = mix_old(out, sm_mono)
    if mono != old:
        print(f"| {str(out):8} | {str(mono):12} | {str(old):12} |")

print(f"\n# test 3: old stereo vs new stereo (diffs)\n")
print("| out      | old stereo   | new stereo   |")
print("| -------- | ------------ | ------------ |")
for out in itertools.combinations(range(16), 2):
    old = mix_old(out, sm_mono)
    new = mix_new(out, sm_mono)
    if old != new:
        print(f"| {str(out):8} | {str(old):12} | {str(new):12} |")

print("\n# test 4: pulse vol mix: old stereo vs new stereo (diffs)\n")
print("| mix | out      | old stereo   = sum  | new stereo   = sum  | new mono     |")
print("| --- | -------- | ------------------- | ------------------- | ------------ |")
for pan in (0, 64, 128, 192, 256):
    sm = stereo_mix(pan)
    for out in itertools.combinations(range(16), 2):
        old = mix_old(out, sm)
        new = mix_new(out, sm)
        mono = mix_mono_new(out)
        if old != new:
            print(f"| {pan:3} | {str(out):8} | {str(old):12} = {sum(old):4} | {str(new):12} = {sum(new):4} | {str(mono):12} |")
```